### PR TITLE
Only use `--orphan` to create new `gh-pages` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You want to make sure your branch already exists.
 
 ```bash
 $ git checkout master
-$ git checkout -b --orphan gh-pages
+$ git checkout --orphan gh-pages
 $ git push origin -u gh-pages
 $ git checkout master
 ```


### PR DESCRIPTION
The `--orphan` and `-b` flags are mutually exclusive according to https://git-scm.com/docs/git-checkout/1.7.3.1

Using `--orphan` on its own is enough to create a named orphan branch.

Currently testing by following the tutorial for a new project I'm setting up and I bumped into this one.